### PR TITLE
Fix the route autowiring system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
           env: SKIP_OEL=true
         - php: 5.6
         - php: 7.0
+        - php: 7.0
           env: DEPENDENCIES='dev'
         - php: 7.1
           env: DEPENDENCIES='low'
@@ -36,6 +37,7 @@ before_install:
 install:
     - export SYMFONY_PHPUNIT_REMOVE="symfony/yaml"
     - export SYMFONY_DEPRECATIONS_HELPER=strict
+    - if [ "$DEPENDENCIES" == "low" ]; then export SYMFONY_DEPRECATIONS_HELPER=disabled; fi;
     - if [ "$DEPENDENCIES" == "dev" ]; then composer config minimum-stability dev; fi;
     - if [ "$DEPENDENCIES" != "low" ]; then composer update --prefer-dist --no-progress --no-suggest --ansi; fi;
     - if [ "$DEPENDENCIES" == "low" ]; then composer update --prefer-dist --no-progress --no-suggest --ansi --prefer-lowest; fi;

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "symfony/framework-bundle": "^3.0"
+        "symfony/framework-bundle": "^2.8.9 || ^3.0"
     },
     "autoload": {
         "psr-4": {
@@ -26,8 +26,11 @@
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^3.2",
-        "symfony/yaml": "^3.0",
-        "matthiasnoback/symfony-dependency-injection-test": "^0.7.6"
+        "symfony/yaml": "^2.8.9 || ^3.0",
+        "symfony/property-access": "^2.8.9 || ^3.0",
+        "symfony/browser-kit": "^2.8.9 || ^3.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^0.7.6",
+        "matthiasnoback/symfony-service-definition-validator": "^1.2.6"
     },
     "extra": {
         "branch-alias": {

--- a/src/DependencyInjection/Compiler/RouteResourcePass.php
+++ b/src/DependencyInjection/Compiler/RouteResourcePass.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Rollerworks RouteAutowiringBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\RouteAutowiringBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * RouteResourcePass registers the route resources on RouteSlotLoader service.
+ *
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+final class RouteResourcePass implements CompilerPassInterface
+{
+    const TAG_NAME = 'rollerworks_route_autowiring.tracked_resource';
+
+    /**
+     * You can modify the container here before it is dumped to PHP code.
+     *
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has('rollerworks_route_autowiring.route_loader') || !$container->getParameter('kernel.debug')) {
+            return;
+        }
+
+        $trackedResources = array_map(
+            function ($id) {
+                return new Reference($id);
+            },
+            array_keys($container->findTaggedServiceIds(self::TAG_NAME))
+        );
+
+        $container->getDefinition('rollerworks_route_autowiring.route_loader')->replaceArgument(2, $trackedResources);
+    }
+}

--- a/src/ResourceLoader.php
+++ b/src/ResourceLoader.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Rollerworks RouteAutowiringBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\RouteAutowiringBundle;
+
+use Symfony\Component\Config\Loader\Loader;
+use Symfony\Component\Config\Loader\LoaderResolverInterface;
+
+/**
+ * The ResourceLoader provides a service-level access to the
+ * Routing loader resolver.
+ *
+ * @internal
+ */
+final class ResourceLoader extends Loader
+{
+    public function __construct(LoaderResolverInterface $resolver)
+    {
+        $this->resolver = $resolver;
+    }
+
+    public function load($resource, $type = null)
+    {
+        return $this->import($resource, $type);
+    }
+
+    /**
+     * Noop implementation, always returns false.
+     */
+    public function supports($resource, $type = null)
+    {
+        return false;
+    }
+}

--- a/src/Resources/config/services/routing.xml
+++ b/src/Resources/config/services/routing.xml
@@ -5,8 +5,15 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="rollerworks_route_autowiring.route_loader" class="Rollerworks\Bundle\RouteAutowiringBundle\RouteSlotLoader">
-            <argument type="collection" />
+        <service id="rollerworks_route_autowiring.route_loader" class="Rollerworks\Bundle\RouteAutowiringBundle\RouteSlotLoader" public="false">
+            <tag name="routing.loader" />
+            <argument type="service" id="service_container" />
+            <argument type="collection" /> <!-- Routing imports. Populated by RouteAutowiringPass -->
+            <argument type="collection" /> <!-- Tracked resources. Populated by RouteAutowiringPass -->
+        </service>
+
+        <service id="rollerworks_route_autowiring.resource_loader" class="Rollerworks\Bundle\RouteAutowiringBundle\ResourceLoader" public="false">
+            <argument type="service" id="routing.resolver" />
         </service>
     </services>
 </container>

--- a/src/RollerworksRouteAutowiringBundle.php
+++ b/src/RollerworksRouteAutowiringBundle.php
@@ -11,7 +11,10 @@
 
 namespace Rollerworks\Bundle\RouteAutowiringBundle;
 
+use Rollerworks\Bundle\RouteAutowiringBundle\DependencyInjection\Compiler\RouteAutowiringPass;
+use Rollerworks\Bundle\RouteAutowiringBundle\DependencyInjection\Compiler\RouteResourcePass;
 use Rollerworks\Bundle\RouteAutowiringBundle\DependencyInjection\RouteAutowiringExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class RollerworksRouteAutowiringBundle extends Bundle
@@ -23,6 +26,12 @@ class RollerworksRouteAutowiringBundle extends Bundle
         }
 
         return $this->extension;
+    }
+
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new RouteAutowiringPass());
+        $container->addCompilerPass(new RouteResourcePass());
     }
 
     protected function getContainerExtensionClass()

--- a/src/RouteImporter.php
+++ b/src/RouteImporter.php
@@ -12,7 +12,10 @@
 namespace Rollerworks\Bundle\RouteAutowiringBundle;
 
 use Rollerworks\Bundle\RouteAutowiringBundle\DependencyInjection\Compiler\RouteAutowiringPass;
+use Rollerworks\Bundle\RouteAutowiringBundle\DependencyInjection\Compiler\RouteResourcePass;
 use Rollerworks\Bundle\RouteAutowiringBundle\DependencyInjection\RouteAutowiringExtension;
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Config\Resource\ResourceInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
@@ -46,12 +49,17 @@ final class RouteImporter
     private $defaultSlot;
 
     /**
+     * @var ResourceInterface[]
+     */
+    private $resources;
+
+    /**
      * Constructor.
      *
-     * @param ContainerBuilder $container   The ContainerBuilder instance
-     *                                      for registering the service definitions on.
-     * @param string|null      $defaultSlot Default slot for resources
-     *                                      (can be overwritten per resource).
+     * @param ContainerBuilder $container   the ContainerBuilder instance
+     *                                      for registering the service definitions on
+     * @param string|null      $defaultSlot default slot for resources
+     *                                      (can be overwritten per resource)
      */
     public function __construct(ContainerBuilder $container, $defaultSlot = null)
     {
@@ -60,19 +68,68 @@ final class RouteImporter
     }
 
     /**
+     * Add resource to track for changes.
+     *
+     * @param ResourceInterface $resource
+     *
+     * @return $this The current instance
+     */
+    public function addResource(ResourceInterface $resource)
+    {
+        $resourceStr = (string) $resource;
+
+        $this->container->register(RouteAutowiringExtension::EXTENSION_ALIAS.'.resources.'.sha1($resourceStr), get_class($resource))
+            ->setPublic(false)
+            ->setArguments([$resourceStr])
+            ->addTag(RouteResourcePass::TAG_NAME);
+
+        return $this;
+    }
+
+    /**
+     * Adds the object class hierarchy as tracked resources.
+     *
+     * @param object $object An object instance
+     *
+     * @return $this The current instance
+     */
+    public function addObjectResource($object)
+    {
+        $this->addClassResource(new \ReflectionClass($object));
+
+        return $this;
+    }
+
+    /**
+     * Adds the given class hierarchy as tracked resources.
+     *
+     * @param \ReflectionClass $class
+     *
+     * @return $this The current instance
+     */
+    public function addClassResource(\ReflectionClass $class)
+    {
+        do {
+            $this->addResource(new FileResource($class->getFileName()));
+        } while ($class = $class->getParentClass());
+
+        return $this;
+    }
+
+    /**
      * Import a routing file into to the routing-slot.
      *
      * The route resource is registered as private service.
      *
-     * @param string|array $resource Resource to import (depends on the actual type).
+     * @param string|array $resource resource to import (depends on the actual type)
      * @param string|null  $slot     The routing-slot to import to.
      *                               Uses the default when none is provided.
-     * @param string|null  $type     The type of the resource (optional),
-     *                               required if the type is not auto guessable.
+     * @param string|null  $type     the type of the resource (optional),
+     *                               required if the type is not auto guessable
      *
-     * @throws \InvalidArgumentException When no (default) slot is provided.
+     * @throws \InvalidArgumentException when no (default) slot is provided
      *
-     * @return self
+     * @return $this The current instance
      */
     public function import($resource, $slot = null, $type = null)
     {

--- a/tests/DependencyInjection/Compiler/RouteResourcePassTest.php
+++ b/tests/DependencyInjection/Compiler/RouteResourcePassTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the Rollerworks RouteAutowiringBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\RouteAutowiringBundle\Tests\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Rollerworks\Bundle\RouteAutowiringBundle\DependencyInjection\Compiler\RouteResourcePass;
+use Rollerworks\Bundle\RouteAutowiringBundle\RouteImporter;
+use Rollerworks\Bundle\RouteAutowiringBundle\RouteSlotLoader;
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class RouteResourcePassTest extends AbstractCompilerPassTestCase
+{
+    /**
+     * @before
+     */
+    public function registerRouteLoader()
+    {
+        $this->container->register('rollerworks_route_autowiring.route_loader', RouteSlotLoader::class)
+            ->setArguments([new Reference('service_container'), [], []]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_registers_the_route_resources()
+    {
+        $routeImporter = new RouteImporter($this->container);
+        $routeImporter->addObjectResource($this);
+        $routeImporter->import('first.yml', 'main');
+        $routeImporter->import('second.yml', 'main');
+        $this->compile();
+
+        $loaderDef = $this->container->findDefinition('rollerworks_route_autowiring.route_loader');
+        $resources = $loaderDef->getArgument(2);
+
+        // Resources are provided as service References, but id cannot be predicted.
+        // So instead loop trough each and analyze the actual referenced service definition.
+        $expectedFilename = (new \ReflectionClass($this))->getFileName();
+        $found = false;
+
+        /** @var Definition[] $resourceServices */
+        $resourceServices = [];
+
+        foreach ($resources as $serviceId) {
+            $resourceServices[(string) $serviceId] = $this->container->findDefinition((string) $serviceId);
+        }
+
+        // assertContains() doesn't work because of to much factors
+        // we only care for the class and argument.
+        foreach ($resourceServices as $resourceService) {
+            if ($resourceService->getClass() !== FileResource::class) {
+                continue;
+            }
+
+            if ($expectedFilename === $resourceService->getArgument(0)) {
+                $found = true;
+
+                break;
+            }
+        }
+
+        if (!$found) {
+            $this->fail("Expected resource '$expectedFilename' in the resource list.");
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_register_the_route_resources_when_debugging_is_disabled()
+    {
+        $routeImporter = new RouteImporter($this->container);
+        $routeImporter->addObjectResource($this);
+        $routeImporter->import('first.yml', 'main');
+        $routeImporter->import('second.yml', 'main');
+
+        $this->setParameter('kernel.debug', false);
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('rollerworks_route_autowiring.route_loader', 2, []);
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new RouteResourcePass());
+        $container->setParameter('kernel.debug', true);
+    }
+}

--- a/tests/Functional/Application/AppBundle/AppBundle.php
+++ b/tests/Functional/Application/AppBundle/AppBundle.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\RouteAutowiringBundle\Tests\Functional\Application\AppBundle;
+
+use Rollerworks\Bundle\RouteAutowiringBundle\Tests\Functional\Application\AppBundle\DependencyInjection\AppExtension;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+final class AppBundle extends Bundle
+{
+    public function getContainerExtension()
+    {
+        return new AppExtension();
+    }
+}

--- a/tests/Functional/Application/AppBundle/Controller/MainController.php
+++ b/tests/Functional/Application/AppBundle/Controller/MainController.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\RouteAutowiringBundle\Tests\Functional\Application\AppBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class MainController extends Controller
+{
+    public function fooAction(Request $request)
+    {
+        return new Response('Route: '.$request->attributes->get('_route'));
+    }
+}

--- a/tests/Functional/Application/AppBundle/DependencyInjection/AppExtension.php
+++ b/tests/Functional/Application/AppBundle/DependencyInjection/AppExtension.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rollerworks\Bundle\RouteAutowiringBundle\Tests\Functional\Application\AppBundle\DependencyInjection;
+
+use Rollerworks\Bundle\RouteAutowiringBundle\RouteImporter;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+
+class AppExtension extends Extension
+{
+    public function load(array $config, ContainerBuilder $container)
+    {
+        $routeImporter = new RouteImporter($container);
+        $routeImporter->addObjectResource($this);
+
+        $routeImporter->import('@AppBundle/Resources/config/routing/frontend.yml', 'frontend');
+
+        if ($container->hasParameter('enable_backend') && $container->getParameter('enable_backend')) {
+            $routeImporter->import('@AppBundle/Resources/config/routing/backend.yml', 'backend');
+        }
+    }
+}

--- a/tests/Functional/Application/AppBundle/Resources/config/routing/backend.yml
+++ b/tests/Functional/Application/AppBundle/Resources/config/routing/backend.yml
@@ -1,0 +1,3 @@
+_products:
+    resource: "backend/products.yml"
+    prefix:   /products

--- a/tests/Functional/Application/AppBundle/Resources/config/routing/backend/products.yml
+++ b/tests/Functional/Application/AppBundle/Resources/config/routing/backend/products.yml
@@ -1,0 +1,9 @@
+backend_products_show:
+    path: /show/{id}
+    defaults: { _controller: "AppBundle:Main:foo" }
+    requirements:
+        id: '\d+'
+
+backend_products_list:
+    path: /list
+    defaults: { _controller: "AppBundle:Main:foo" }

--- a/tests/Functional/Application/AppBundle/Resources/config/routing/frontend.yml
+++ b/tests/Functional/Application/AppBundle/Resources/config/routing/frontend.yml
@@ -1,0 +1,7 @@
+_products:
+    resource: "frontend/products.yml"
+    prefix:   /products
+
+_cart:
+    resource: "frontend/cart.yml"
+    prefix:   /cart

--- a/tests/Functional/Application/AppBundle/Resources/config/routing/frontend/cart.yml
+++ b/tests/Functional/Application/AppBundle/Resources/config/routing/frontend/cart.yml
@@ -1,0 +1,7 @@
+frontend_cart_show:
+    path: /show
+    defaults: { _controller: "AppBundle:Main:foo" }
+
+frontend_cart_clear:
+    path: /clear
+    defaults: { _controller: "AppBundle:Main:foo" }

--- a/tests/Functional/Application/AppBundle/Resources/config/routing/frontend/products.yml
+++ b/tests/Functional/Application/AppBundle/Resources/config/routing/frontend/products.yml
@@ -1,0 +1,7 @@
+frontend_products_show:
+    path: /show
+    defaults: { _controller: "AppBundle:Main:foo" }
+
+frontend_products_search:
+    path: /search
+    defaults: { _controller: "AppBundle:Main:foo" }

--- a/tests/Functional/Application/AppKernel.php
+++ b/tests/Functional/Application/AppKernel.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\RouteAutowiringBundle\Tests\Functional\Application;
+
+use Matthias\SymfonyServiceDefinitionValidator\Compiler\ValidateServiceDefinitionsPass;
+use Matthias\SymfonyServiceDefinitionValidator\Configuration;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\DependencyInjection\MergeExtensionConfigurationPass;
+use Symfony\Component\HttpKernel\Kernel;
+
+class AppKernel extends Kernel
+{
+    private $config;
+
+    public function __construct($config, $debug = true)
+    {
+        if (!(new Filesystem())->isAbsolutePath($config)) {
+            $config = __DIR__.'/config/'.$config;
+        }
+
+        if (!file_exists($config)) {
+            throw new \RuntimeException(sprintf('The config file "%s" does not exist.', $config));
+        }
+
+        $this->config = $config;
+
+        parent::__construct('test', $debug);
+    }
+
+    public function getName()
+    {
+        return 'RouteAutowiring'.substr(sha1($this->config), 0, 3);
+    }
+
+    public function registerBundles()
+    {
+        $bundles = [
+            new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+            new \Rollerworks\Bundle\RouteAutowiringBundle\RollerworksRouteAutowiringBundle(),
+
+            new AppBundle\AppBundle(),
+        ];
+
+        return $bundles;
+    }
+
+    public function getRootDir()
+    {
+        if (null === $this->rootDir) {
+            $this->rootDir = str_replace('\\', '/', __DIR__);
+        }
+
+        return $this->rootDir;
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load($this->config);
+    }
+
+    public function getCacheDir()
+    {
+        return (getenv('TMPDIR') ?: sys_get_temp_dir()).'/RouteAutowiring/'.substr(sha1($this->config), 0, 6);
+    }
+
+    public function serialize()
+    {
+        return serialize([$this->config, $this->isDebug()]);
+    }
+
+    public function unserialize($str)
+    {
+        call_user_func_array([$this, '__construct'], unserialize($str));
+    }
+
+    protected function prepareContainer(ContainerBuilder $container)
+    {
+        $extensions = [];
+
+        foreach ($this->bundles as $bundle) {
+            if ($extension = $bundle->getContainerExtension()) {
+                $container->registerExtension($extension);
+                $extensions[] = $extension->getAlias();
+            }
+
+            if ($this->debug) {
+                $container->addObjectResource($bundle);
+            }
+        }
+
+        foreach ($this->bundles as $bundle) {
+            $bundle->build($container);
+        }
+
+        $this->buildBundleless($container);
+
+        // ensure these extensions are implicitly loaded
+        $container->getCompilerPassConfig()->setMergePass(new MergeExtensionConfigurationPass($extensions));
+    }
+
+    private function buildBundleless(ContainerBuilder $container)
+    {
+        if ($container->getParameter('kernel.debug')) {
+            $configuration = new Configuration();
+            $configuration->setEvaluateExpressions(true);
+
+            $container->addCompilerPass(
+                new ValidateServiceDefinitionsPass($configuration),
+                PassConfig::TYPE_AFTER_REMOVING
+            );
+        }
+    }
+}

--- a/tests/Functional/Application/config/default.yml
+++ b/tests/Functional/Application/config/default.yml
@@ -1,0 +1,2 @@
+imports:
+    - { resource: framework.yml }

--- a/tests/Functional/Application/config/framework.yml
+++ b/tests/Functional/Application/config/framework.yml
@@ -1,0 +1,16 @@
+framework:
+    translator:          false
+    secret:              test
+    router:
+        resource: '%kernel.root_dir%/config/routing.yml'
+        strict_requirements: '%kernel.debug%'
+    form:                false
+    csrf_protection:     false
+    validation:          false
+    templating:          false
+    default_locale:      en
+    trusted_proxies:     []
+    session:
+        storage_id: session.storage.filesystem
+    test:                ~
+    assets: false

--- a/tests/Functional/Application/config/routing.yml
+++ b/tests/Functional/Application/config/routing.yml
@@ -1,0 +1,9 @@
+_frontend:
+    resource: "frontend"
+    type: rollerworks_autowiring
+    prefix:   /
+
+_backend:
+    resource: "backend"
+    type: rollerworks_autowiring
+    prefix: backend/

--- a/tests/Functional/Application/config/with_backend.yml
+++ b/tests/Functional/Application/config/with_backend.yml
@@ -1,0 +1,5 @@
+parameters:
+    enable_backend: true
+
+imports:
+    - { resource: framework.yml }

--- a/tests/Functional/FunctionalTestCase.php
+++ b/tests/Functional/FunctionalTestCase.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\RouteAutowiringBundle\Tests\Functional;
+
+use Rollerworks\Bundle\RouteAutowiringBundle\Tests\Functional\Application\AppKernel;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+abstract class FunctionalTestCase extends WebTestCase
+{
+    protected static function createKernel(array $options = [])
+    {
+        return new Application\AppKernel(
+            isset($options['config']) ? $options['config'] : 'default.yml'
+        );
+    }
+
+    protected static function getKernelClass()
+    {
+        return AppKernel::class;
+    }
+
+    /**
+     * @param array $options
+     * @param array $server
+     *
+     * @return \Symfony\Bundle\FrameworkBundle\Client
+     */
+    protected static function newClient(array $options = [], array $server = [])
+    {
+        $client = static::createClient(array_merge(['config' => 'default.yml'], $options), $server);
+
+        $warmer = $client->getContainer()->get('cache_warmer');
+        $warmer->warmUp($client->getContainer()->getParameter('kernel.cache_dir'));
+        $warmer->enableOptionalWarmers();
+
+        return $client;
+    }
+}

--- a/tests/Functional/RouteLoaderTest.php
+++ b/tests/Functional/RouteLoaderTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the RollerworksSearch package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\RouteAutowiringBundle\Tests\Functional;
+
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+final class RouteLoaderTest extends FunctionalTestCase
+{
+    /**
+     * @dataProvider provideExpectedImportedRoutes
+     */
+    public function testRoutesToImportedRoutes($uri, $expectedRoute)
+    {
+        $client = self::newClient();
+
+        $client->request('GET', $uri);
+        $this->assertEquals('Route: '.$expectedRoute, $client->getResponse()->getContent());
+    }
+
+    public function testFailsWithNonImportedRoutes()
+    {
+        $client = self::newClient();
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('/backend/products/list');
+
+        $client->request('GET', '/backend/products/list');
+    }
+
+    public function testRoutesToAutowiredRouteWhenEnabled()
+    {
+        $client = self::newClient(['config' => 'with_backend.yml']);
+
+        $client->request('GET', '/backend/products/list');
+        $this->assertEquals('Route: backend_products_list', $client->getResponse()->getContent());
+
+        $client->request('GET', '/backend/products/show/50');
+        $this->assertEquals('Route: backend_products_show', $client->getResponse()->getContent());
+    }
+
+    public function provideExpectedImportedRoutes()
+    {
+        return [
+            'frontend_products_show' => ['/products/show', 'frontend_products_show'],
+            'frontend_products_search' => ['/products/search', 'frontend_products_search'],
+
+            // Second import
+            'frontend_cart_show' => ['/cart/show', 'frontend_cart_show'],
+            'frontend_cart_clear' => ['/cart/clear', 'frontend_cart_clear'],
+        ];
+    }
+}

--- a/tests/RouteSlotLoaderTest.php
+++ b/tests/RouteSlotLoaderTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Rollerworks\Bundle\RouteAutowiringBundle\Tests;
+
+use Rollerworks\Bundle\RouteAutowiringBundle\RouteSlotLoader;
+use Symfony\Component\Config\Resource\ResourceInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\RouteCollectionBuilder;
+
+final class RouteSlotLoaderTest extends \PHPUnit_Framework_TestCase
+{
+    /** @test */
+    public function it_supports_only_autowired_routes()
+    {
+        $loader = new RouteSlotLoader($this->getContainer(), []);
+
+        self::assertTrue($loader->supports('main', 'rollerworks_autowiring'));
+        self::assertFalse($loader->supports('main', 'yaml'));
+    }
+
+    /** @test */
+    public function it_loads_a_route_collection_from_the_container()
+    {
+        $aR = new RouteCollectionBuilder();
+        $aR->add('main/', 'MainController', 'main');
+
+        $bR = new RouteCollectionBuilder();
+        $bR->add('backend/', 'BackendController', 'backend_main');
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get($a = 'rollerworks_route_autowiring.routing_slot.frontend')->willReturn($aR);
+        $container->get($b = 'rollerworks_route_autowiring.routing_slot.backend')->willReturn($bR);
+
+        $loader = new RouteSlotLoader($container->reveal(), ['frontend' => $a, 'backend' => $b]);
+
+        self::assertInstanceOf(RouteCollection::class, $routeCollection = $loader->load('frontend'));
+        self::assertArrayHasKey('main', $routeCollection->getIterator());
+        self::assertArrayNotHasKey('backend_main', $routeCollection->getIterator());
+
+        self::assertInstanceOf(RouteCollection::class, $routeCollection = $loader->load('backend'));
+        self::assertArrayHasKey('backend_main', $routeCollection->getIterator());
+        self::assertArrayNotHasKey('main', $routeCollection->getIterator());
+
+        // While not existing it should not fail.
+        self::assertInstanceOf(RouteCollection::class, $routeCollection = $loader->load('unknown'));
+        self::assertEmpty($routeCollection->getIterator());
+    }
+
+    /** @test */
+    public function it_registers_resources_on_all_collections()
+    {
+        $routeCollectionBuilder = new RouteCollectionBuilder();
+        $routeCollectionBuilder->add('main/', 'MainController', 'main');
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get($a = 'rollerworks_route_autowiring.routing_slot.frontend')->willReturn($routeCollectionBuilder);
+
+        $loader = new RouteSlotLoader(
+            $container->reveal(), ['frontend' => $a],
+            [$r = $this->createResourceStub(), $r2 = $this->createResourceStub('stub2')]
+        );
+
+        self::assertInstanceOf(RouteCollection::class, $routeCollection = $loader->load('frontend'));
+        self::assertArrayHasKey('main', $routeCollection->getIterator());
+
+        $resources = $routeCollection->getResources();
+        self::assertContains($r, $resources);
+        self::assertContains($r2, $resources);
+
+        // Even when the slot is not registered the resources should still be registered
+        // as they can be enabled in the future.
+        self::assertInstanceOf(RouteCollection::class, $routeCollection = $loader->load('backend'));
+        self::assertArrayNotHasKey('main', $routeCollection->getIterator());
+
+        $resources = $routeCollection->getResources();
+        self::assertContains($r, $resources);
+        self::assertContains($r2, $resources);
+    }
+
+    private function createResourceStub($name = 'stub')
+    {
+        $resource = $this->getMockBuilder(ResourceInterface::class)->getMock();
+        $resource->expects(self::any())->method('__toString')->willReturn($name);
+
+        return $resource;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|ContainerInterface
+     */
+    private function getContainer()
+    {
+        return $this->getMockBuilder(ContainerInterface::class)->getMock();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

It actually seemed the entire system was broken by design!

Routes were never registered and thus never loaded, and once the CompilerPass responsible for loading was registered, a circular dependency was revealed.

To ensure this bundle is working and will continue to work, the tests have been greatly improved and functional tests were added.

Secondly a resource tracking system was added to ensure, disabling/enabling a routing import is properly reloaded. The developer however does need to register the resources manually.

**Note:** Unless you use the internal API directly (not recommended) things should work as documented.