### PR TITLE
Remove resource after registration

### DIFF
--- a/src/DependencyInjection/Compiler/RouteAutowiringPass.php
+++ b/src/DependencyInjection/Compiler/RouteAutowiringPass.php
@@ -60,6 +60,7 @@ final class RouteAutowiringPass implements CompilerPassInterface
             /** @var RouteResource $resource */
             $resource = $container->get($id);
             $slotServices[$slot]->addMethodCall('import', [$resource->getResource(), '/', $resource->getType()]);
+            $container->removeDefinition($id);
         }
 
         $container->getDefinition('rollerworks_route_autowiring.route_loader')->replaceArgument(1, $slotsToServiceIds);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

Symfony 4.1 allows to get private services for testing, but the route autowiring services
are removed after the collector pass is done. To prevent getting unregistered service warnings
remove the resource service after processing.

There are no tests, but I confirmed this in a another project.