### PR TITLE
Add support for Symfony 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.phar
 /vendor/
 .php_cs.cache
+.phpunit.result.cache
+symfony.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,41 +1,49 @@
 language: php
 
-sudo: false
+dist: xenial
+
+env:
+    global:
+        - SYMFONY_PHPUNIT_DISABLE_RESULT_CACHE=1
 
 matrix:
     include:
-        - php: 5.6
-        - php: 7.1
-          env: deps='dev'
-        - php: 7.1
-          env: deps='low'
-        - php: 7.1
-          env: lint=1
+        - php: 7.2
+          #env:
+          #  - SYMFONY_REQUIRE='^4.4'
+        - php: 7.3
+          env:
+            - lint=1
+            - QA_DOCKER_IMAGE=jakzal/phpqa:1.25.0-php7.3-alpine
+          services:
+              - docker
     fast_finish: true
+
+sudo: false
 
 cache:
     directories:
-        - $HOME/.composer/cache
+        - $HOME/.composer/cache/files
 
 before_install:
     - phpenv config-rm xdebug.ini || echo "xdebug not available"
     - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-    - if [[ $lint = 1 ]]; then wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.3.2/php-cs-fixer.phar; fi
-    - if [[ $lint = 1 ]]; then composer global require --dev 'phpstan/phpstan:^0.8'; fi
+    - composer global require symfony/flex
+
+    - if [[ $lint = 1 ]]; then docker pull ${QA_DOCKER_IMAGE}; fi
     - export PATH="$PATH:$HOME/.composer/vendor/bin"
 
 install:
-    - if [[ ! $deps ]]; then composer update --prefer-dist --no-progress --no-suggest --ansi; fi
-    - if [[ $deps = 'dev' ]]; then composer config minimum-stability dev && composer config prefer-stable false && composer update --prefer-dist --no-progress --no-suggest --ansi ; fi
-    - if [[ $deps = 'low' ]]; then composer update --prefer-dist --no-progress --no-suggest --prefer-stable --prefer-lowest --ansi; fi
+    - composer install --prefer-dist --no-progress --no-suggest --ansi
 
 script:
+    - vendor/bin/phpunit --verbose
     - |
-        if [[ $deps = 'dev' ]]; then
-            export SYMFONY_DEPRECATIONS_HELPER=weak
-        else
-            export SYMFONY_DEPRECATIONS_HELPER=strict
+        if [[ $lint = 1 ]]
+        then
+            mkdir /tmp/tmp-phpqa-$(id -u)
+            export QA_DOCKER_COMMAND="docker run --init --interactive --tty --rm --user "$(id -u):$(id -g)" --volume /tmp/tmp-phpqa-$(id -u):/tmp --volume "$(pwd):/project" --workdir /project ${QA_DOCKER_IMAGE}"
+            sh -c "${QA_DOCKER_COMMAND} php-cs-fixer fix -vvv --diff --dry-run"
+            sh -c "${QA_DOCKER_COMMAND} phpstan analyse"
+            #sh -c "${QA_DOCKER_COMMAND} vendor/bin/psalm --show-info=false"
         fi
-    - if [[ ! $lint ]]; then vendor/bin/phpunit --verbose; fi
-    - if [[ $lint = 1 ]]; then php php-cs-fixer.phar fix --dry-run --diff --no-ansi; fi
-    - if [[ $lint = 1 ]]; then phpstan analyse -c phpstan.neon -l5 --ansi src tests; fi

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Rollerworks RouteAutowiringBundle
 =================================
 
-The RollerworksRouteAutoWiringBundle allows to import multiple route collections
+The RollerworksRouteAutowiringBundle allows to import multiple route collections
 using an autowiring system.
 
 For example you have BundleA which defines some routes, to use them you
@@ -19,7 +19,7 @@ from a file or service you load them using the autowiring system.
 Requirements
 ------------
 
-You need at least PHP 5.6 and the Symfony FrameworkBundle.
+You need at least PHP 7.1 and the Symfony FrameworkBundle.
 
 Installation
 ------------
@@ -34,32 +34,6 @@ $ php composer.phar require rollerworks/route-autowiring-bundle
 This command requires you to have Composer installed globally, as explained
 in the [installation chapter](https://getcomposer.org/doc/00-intro.md)
 of the Composer documentation.
-
-Then, enable the bundle by adding it to the list of registered bundles
-in the `app/AppKernel.php` file of your project (**you can skip this step
-when you're using [Symfony Flex](https://github.com/symfony/flex)**):
-
-```php
-<?php
-// app/AppKernel.php
-
-// ...
-class AppKernel extends Kernel
-{
-    public function registerBundles()
-    {
-        $bundles = [
-            // ...
-            new Rollerworks\Bundle\RouteAutowiringBundle\RollerworksRouteAutowiringBundle(),
-            // ...
-        ];
-
-        // ...
-    }
-
-    // ...
-}
-```
 
 Basic usage
 -----------
@@ -104,7 +78,7 @@ class AcmeShopExtension extends Extension
 {
     // ...
 
-    public function load(array $configs, ContainerBuilder $container);
+    public function load(array $configs, ContainerBuilder $container): void
     {
         // ...
 

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
-        "symfony/framework-bundle": "^2.8.9 || ^3.3.6 || ^4.0"
+        "php": "^7.2",
+        "symfony/framework-bundle": "^5.0"
     },
     "autoload": {
         "psr-4": {
@@ -27,18 +27,17 @@
         }
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^4.1",
-        "symfony/yaml": "^2.8.9 || ^3.3.6 || ^4.0",
-        "symfony/property-access": "^2.8.9 || ^3.3.6 || ^4.0",
-        "symfony/browser-kit": "^2.8.9 || ^3.3.6 || ^4.0",
-        "matthiasnoback/symfony-dependency-injection-test": "^1.1.0 || ^2.3.1 || ^3.0.0",
-        "phpunit/phpunit": "^5.7.27 || ^6.5.8",
-        "symfony/expression-language": "^2.8.9 || ^3.3.6 || ^4.0",
-        "psr/container": "^1.0"
+        "symfony/phpunit-bridge": "^5.0",
+        "symfony/yaml": "^5.0",
+        "symfony/property-access": "^5.0",
+        "symfony/browser-kit": "^5.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.1.0",
+        "phpunit/phpunit": "^8.4.3",
+        "symfony/expression-language": "^5.0"
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "1.2-dev"
         }
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,10 +1,19 @@
+includes:
+	- /tools/.composer/vendor-bin/phpstan/vendor/phpstan/phpstan-phpunit/extension.neon
+
 parameters:
     autoload_files:
         - vendor/autoload.php
 
+    level: 5
+    paths:
+        - ./src
+#        - ./tests
+
+    checkNullables: false # To many false positives
     ignoreErrors:
         # Tests
-        - '#Call to an undefined method Prophecy\\Prophecy\\ObjectProphecy::[a-zA-Z0-9_]+\(\)#'
+        #- '#Call to an undefined method Prophecy\\Prophecy\\ObjectProphecy::[a-zA-Z0-9_]+\(\)#'
         #- '#Access to an undefined property Prophecy\\Prophecy\\ObjectProphecy::\$[a-zA-Z0-9_]+#'
         #- '#Call to an undefined method PHPUnit_Framework_MockObject_MockObject::[a-zA-Z0-9_]+\(\)#'
         #- '#expects\s+[^\s]+, PHPUnit_Framework_MockObject_MockObject(\[\])? given#'

--- a/src/DependencyInjection/Compiler/RouteAutowiringPass.php
+++ b/src/DependencyInjection/Compiler/RouteAutowiringPass.php
@@ -30,12 +30,7 @@ final class RouteAutowiringPass implements CompilerPassInterface
 {
     const TAG_NAME = 'rollerworks_route_autowiring.route_resource';
 
-    /**
-     * You can modify the container here before it is dumped to PHP code.
-     *
-     * @param ContainerBuilder $container
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->has('rollerworks_route_autowiring.route_loader') || !$container->has('routing.loader')) {
             return;

--- a/src/DependencyInjection/Compiler/RouteResourcePass.php
+++ b/src/DependencyInjection/Compiler/RouteResourcePass.php
@@ -24,12 +24,7 @@ final class RouteResourcePass implements CompilerPassInterface
 {
     const TAG_NAME = 'rollerworks_route_autowiring.tracked_resource';
 
-    /**
-     * You can modify the container here before it is dumped to PHP code.
-     *
-     * @param ContainerBuilder $container
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->has('rollerworks_route_autowiring.route_loader') || !$container->getParameter('kernel.debug')) {
             return;

--- a/src/DependencyInjection/RouteAutowiringExtension.php
+++ b/src/DependencyInjection/RouteAutowiringExtension.php
@@ -11,6 +11,7 @@
 
 namespace Rollerworks\Bundle\RouteAutowiringBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
@@ -18,20 +19,20 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 final class RouteAutowiringExtension extends Extension
 {
-    const EXTENSION_ALIAS = 'rollerworks_route_autowiring';
+    public const EXTENSION_ALIAS = 'rollerworks_route_autowiring';
 
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config/services/'));
         $loader->load('routing.xml');
     }
 
-    public function getConfiguration(array $config, ContainerBuilder $container)
+    public function getConfiguration(array $config, ContainerBuilder $container): ?ConfigurationInterface
     {
-        // no-op
+        return null;
     }
 
-    public function getAlias()
+    public function getAlias(): string
     {
         return self::EXTENSION_ALIAS;
     }

--- a/src/ResourceLoader.php
+++ b/src/ResourceLoader.php
@@ -27,7 +27,7 @@ final class ResourceLoader extends Loader
         $this->resolver = $resolver;
     }
 
-    public function load($resource, $type = null)
+    public function load($resource, string $type = null)
     {
         return $this->import($resource, $type);
     }
@@ -35,7 +35,7 @@ final class ResourceLoader extends Loader
     /**
      * Noop implementation, always returns false.
      */
-    public function supports($resource, $type = null)
+    public function supports($resource, string $type = null)
     {
         return false;
     }

--- a/src/RollerworksRouteAutowiringBundle.php
+++ b/src/RollerworksRouteAutowiringBundle.php
@@ -15,11 +15,12 @@ use Rollerworks\Bundle\RouteAutowiringBundle\DependencyInjection\Compiler\RouteA
 use Rollerworks\Bundle\RouteAutowiringBundle\DependencyInjection\Compiler\RouteResourcePass;
 use Rollerworks\Bundle\RouteAutowiringBundle\DependencyInjection\RouteAutowiringExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class RollerworksRouteAutowiringBundle extends Bundle
 {
-    public function getContainerExtension()
+    public function getContainerExtension(): ?ExtensionInterface
     {
         if (null === $this->extension) {
             $this->extension = new RouteAutowiringExtension();
@@ -28,13 +29,13 @@ class RollerworksRouteAutowiringBundle extends Bundle
         return $this->extension;
     }
 
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new RouteAutowiringPass());
         $container->addCompilerPass(new RouteResourcePass());
     }
 
-    protected function getContainerExtensionClass()
+    protected function getContainerExtensionClass(): string
     {
         return RouteAutowiringExtension::class;
     }

--- a/src/RouteImporter.php
+++ b/src/RouteImporter.php
@@ -65,15 +65,13 @@ final class RouteImporter
     /**
      * Add resource to track for changes.
      *
-     * @param ResourceInterface $resource
-     *
      * @return $this The current instance
      */
     public function addResource(ResourceInterface $resource)
     {
         $resourceStr = (string) $resource;
 
-        $this->container->register(RouteAutowiringExtension::EXTENSION_ALIAS.'.resources.'.sha1($resourceStr), get_class($resource))
+        $this->container->register(RouteAutowiringExtension::EXTENSION_ALIAS.'.resources.'.sha1($resourceStr), \get_class($resource))
             ->setPublic(false)
             ->setArguments([$resourceStr])
             ->addTag(RouteResourcePass::TAG_NAME);
@@ -97,8 +95,6 @@ final class RouteImporter
 
     /**
      * Adds the given class hierarchy as tracked resources.
-     *
-     * @param \ReflectionClass $class
      *
      * @return $this The current instance
      */

--- a/src/RouteResource.php
+++ b/src/RouteResource.php
@@ -48,7 +48,7 @@ final class RouteResource
     }
 
     /**
-     * @return null|string
+     * @return string|null
      */
     public function getType()
     {

--- a/src/RouteSlotLoader.php
+++ b/src/RouteSlotLoader.php
@@ -58,10 +58,10 @@ final class RouteSlotLoader extends Loader
      * @param mixed       $resource Some value that will resolve to a callable
      * @param string|null $type     The resource type
      *
-     * @return RouteCollection returns an empty RouteCollection object when noå routes
+     * @return RouteCollection returns an empty RouteCollection object when no routes
      *                         are registered for the slot
      */
-    public function load($resource, $type = null)
+    public function load($resource, string $type = null): RouteCollection
     {
         if (!isset($this->slots[$resource])) {
             $collection = new RouteCollection();
@@ -84,8 +84,8 @@ final class RouteSlotLoader extends Loader
      *
      * @return bool True if this class supports the given resource, false otherwise
      */
-    public function supports($resource, $type = null)
+    public function supports($resource, string $type = null): bool
     {
-        return $type === 'rollerworks_autowiring';
+        return 'rollerworks_autowiring' === $type;
     }
 }

--- a/tests/DependencyInjection/Compiler/RouteAutowiringPassTest.php
+++ b/tests/DependencyInjection/Compiler/RouteAutowiringPassTest.php
@@ -25,7 +25,7 @@ use Symfony\Component\Routing\RouteCollectionBuilder;
 
 final class RouteAutowiringPassTest extends AbstractCompilerPassTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -43,7 +43,7 @@ final class RouteAutowiringPassTest extends AbstractCompilerPassTestCase
             ->setPublic(false);
 
         $this->container->register('file_locator', FileLocator::class)
-            ->setArguments([dirname(__DIR__).'/../Fixtures/']);
+            ->setArguments([\dirname(__DIR__).'/../Fixtures/']);
 
         $this->container->register('routing.loader', YamlFileLoader::class)
             ->setArguments([new Reference('file_locator')]);
@@ -113,7 +113,7 @@ final class RouteAutowiringPassTest extends AbstractCompilerPassTestCase
         $this->assertLoaderHasSlots(['main']);
     }
 
-    protected function registerCompilerPass(ContainerBuilder $container)
+    protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new RouteAutowiringPass());
         $container->setParameter('kernel.debug', true);

--- a/tests/DependencyInjection/Compiler/RouteResourcePassTest.php
+++ b/tests/DependencyInjection/Compiler/RouteResourcePassTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 final class RouteResourcePassTest extends AbstractCompilerPassTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -59,7 +59,7 @@ final class RouteResourcePassTest extends AbstractCompilerPassTestCase
         // assertContains() doesn't work because of to much factors
         // we only care for the class and argument.
         foreach ($resourceServices as $resourceService) {
-            if ($resourceService->getClass() !== FileResource::class) {
+            if (FileResource::class !== $resourceService->getClass()) {
                 continue;
             }
 
@@ -91,7 +91,7 @@ final class RouteResourcePassTest extends AbstractCompilerPassTestCase
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('rollerworks_route_autowiring.route_loader', 2, []);
     }
 
-    protected function registerCompilerPass(ContainerBuilder $container)
+    protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new RouteResourcePass());
         $container->setParameter('kernel.debug', true);

--- a/tests/Functional/Application/AppBundle/AppBundle.php
+++ b/tests/Functional/Application/AppBundle/AppBundle.php
@@ -12,11 +12,12 @@
 namespace Rollerworks\Bundle\RouteAutowiringBundle\Tests\Functional\Application\AppBundle;
 
 use Rollerworks\Bundle\RouteAutowiringBundle\Tests\Functional\Application\AppBundle\DependencyInjection\AppExtension;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 final class AppBundle extends Bundle
 {
-    public function getContainerExtension()
+    public function getContainerExtension(): ?ExtensionInterface
     {
         return new AppExtension();
     }

--- a/tests/Functional/Application/AppBundle/Controller/MainController.php
+++ b/tests/Functional/Application/AppBundle/Controller/MainController.php
@@ -11,11 +11,10 @@
 
 namespace Rollerworks\Bundle\RouteAutowiringBundle\Tests\Functional\Application\AppBundle\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-final class MainController extends Controller
+final class MainController
 {
     public function fooAction(Request $request)
     {

--- a/tests/Functional/Application/AppBundle/DependencyInjection/AppExtension.php
+++ b/tests/Functional/Application/AppBundle/DependencyInjection/AppExtension.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\Extension\Extension;
 
 class AppExtension extends Extension
 {
-    public function load(array $config, ContainerBuilder $container)
+    public function load(array $config, ContainerBuilder $container): void
     {
         $routeImporter = new RouteImporter($container);
         $routeImporter->addObjectResource($this);

--- a/tests/Functional/Application/AppBundle/Resources/config/routing/backend/products.yml
+++ b/tests/Functional/Application/AppBundle/Resources/config/routing/backend/products.yml
@@ -1,9 +1,9 @@
 backend_products_show:
     path: /show/{id}
-    defaults: { _controller: "AppBundle:Main:foo" }
+    defaults: { _controller: 'Rollerworks\Bundle\RouteAutowiringBundle\Tests\Functional\Application\AppBundle\Controller\MainController::fooAction' }
     requirements:
         id: '\d+'
 
 backend_products_list:
     path: /list
-    defaults: { _controller: "AppBundle:Main:foo" }
+    defaults: { _controller: 'Rollerworks\Bundle\RouteAutowiringBundle\Tests\Functional\Application\AppBundle\Controller\MainController::fooAction' }

--- a/tests/Functional/Application/AppBundle/Resources/config/routing/frontend/cart.yml
+++ b/tests/Functional/Application/AppBundle/Resources/config/routing/frontend/cart.yml
@@ -1,7 +1,7 @@
 frontend_cart_show:
     path: /show
-    defaults: { _controller: "AppBundle:Main:foo" }
+    defaults: { _controller: 'Rollerworks\Bundle\RouteAutowiringBundle\Tests\Functional\Application\AppBundle\Controller\MainController::fooAction' }
 
 frontend_cart_clear:
     path: /clear
-    defaults: { _controller: "AppBundle:Main:foo" }
+    defaults: { _controller: 'Rollerworks\Bundle\RouteAutowiringBundle\Tests\Functional\Application\AppBundle\Controller\MainController::fooAction' }

--- a/tests/Functional/Application/AppBundle/Resources/config/routing/frontend/products.yml
+++ b/tests/Functional/Application/AppBundle/Resources/config/routing/frontend/products.yml
@@ -1,7 +1,7 @@
 frontend_products_show:
     path: /show
-    defaults: { _controller: "AppBundle:Main:foo" }
+    defaults: { _controller: 'Rollerworks\Bundle\RouteAutowiringBundle\Tests\Functional\Application\AppBundle\Controller\MainController::fooAction' }
 
 frontend_products_search:
     path: /search
-    defaults: { _controller: "AppBundle:Main:foo" }
+    defaults: { _controller: 'Rollerworks\Bundle\RouteAutowiringBundle\Tests\Functional\Application\AppBundle\Controller\MainController::fooAction' }

--- a/tests/Functional/Application/AppKernel.php
+++ b/tests/Functional/Application/AppKernel.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpKernel\Kernel;
 class AppKernel extends Kernel
 {
     private $config;
+    private $projectDir;
 
     public function __construct($config, $debug = true)
     {
@@ -51,13 +52,13 @@ class AppKernel extends Kernel
         return $bundles;
     }
 
-    public function getRootDir()
+    public function getProjectDir()
     {
-        if (null === $this->rootDir) {
-            $this->rootDir = str_replace('\\', '/', __DIR__);
+        if (null === $this->projectDir) {
+            $this->projectDir = str_replace('\\', '/', __DIR__);
         }
 
-        return $this->rootDir;
+        return $this->projectDir;
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader)
@@ -77,6 +78,6 @@ class AppKernel extends Kernel
 
     public function unserialize($str)
     {
-        call_user_func_array([$this, '__construct'], unserialize($str));
+        \call_user_func_array([$this, '__construct'], unserialize($str));
     }
 }

--- a/tests/Functional/Application/config/framework.yml
+++ b/tests/Functional/Application/config/framework.yml
@@ -2,12 +2,11 @@ framework:
     translator:          false
     secret:              test
     router:
-        resource: '%kernel.root_dir%/config/routing.yml'
+        resource: '%kernel.project_dir%/config/routing.yml'
         strict_requirements: '%kernel.debug%'
     form:                false
     csrf_protection:     false
     validation:          false
-    templating:          false
     default_locale:      en
     session:
         storage_id: session.storage.mock_file

--- a/tests/Functional/FunctionalTestCase.php
+++ b/tests/Functional/FunctionalTestCase.php
@@ -12,6 +12,7 @@
 namespace Rollerworks\Bundle\RouteAutowiringBundle\Tests\Functional;
 
 use Rollerworks\Bundle\RouteAutowiringBundle\Tests\Functional\Application\AppKernel;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 abstract class FunctionalTestCase extends WebTestCase
@@ -28,13 +29,7 @@ abstract class FunctionalTestCase extends WebTestCase
         return AppKernel::class;
     }
 
-    /**
-     * @param array $options
-     * @param array $server
-     *
-     * @return \Symfony\Bundle\FrameworkBundle\Client
-     */
-    protected static function newClient(array $options = [], array $server = [])
+    protected static function newClient(array $options = [], array $server = []): KernelBrowser
     {
         $client = static::createClient(array_merge(['config' => 'default.yml'], $options), $server);
 

--- a/tests/Functional/RouteLoaderTest.php
+++ b/tests/Functional/RouteLoaderTest.php
@@ -34,10 +34,10 @@ final class RouteLoaderTest extends FunctionalTestCase
             $client->request('GET', '/backend/products/list');
             $response = $client->getInternalResponse();
 
-            self::assertEquals(404, $response->getStatus());
-            self::assertContains('No route found for &quot;GET /backend/products/list&quot;', $response->getContent());
+            self::assertEquals(404, $response->getStatusCode());
+            self::assertStringContainsString('No route found for &quot;GET /backend/products/list&quot;', $response->getContent());
         } catch (NotFoundHttpException $e) {
-            self::assertContains('No route found for "GET /backend/products/list"', $e->getMessage());
+            self::assertStringContainsString('No route found for "GET /backend/products/list"', $e->getMessage());
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

This drops support for Symfony 4 and lower (older versions of this bundle still support Symfony and up). There is technically no way to keep support for older versions while supporting newer ones.