### PR TITLE
Remove old BC code

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ from a file or service you load them using the autowiring system.
 Requirements
 ------------
 
-You need at least PHP 7.1 and the Symfony FrameworkBundle.
+You need at least PHP 7.2 and the Symfony FrameworkBundle.
 
 Installation
 ------------

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,6 +12,8 @@ parameters:
 
     checkNullables: false # To many false positives
     ignoreErrors:
+        - '#Strict comparison using === between null and Symfony\\Component\\Config\\Loader\\LoaderResolverInterface will always evaluate to false#'
+
         # Tests
         #- '#Call to an undefined method Prophecy\\Prophecy\\ObjectProphecy::[a-zA-Z0-9_]+\(\)#'
         #- '#Access to an undefined property Prophecy\\Prophecy\\ObjectProphecy::\$[a-zA-Z0-9_]+#'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.7/phpunit.xsd"
-         backupGlobals="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.4/phpunit.xsd"
          colors="true"
          bootstrap="vendor/autoload.php"
          beStrictAboutTestsThatDoNotTestAnything="false"
@@ -32,5 +31,9 @@
             </exclude>
         </whitelist>
     </filter>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 
 </phpunit>

--- a/src/DependencyInjection/Compiler/RouteResourcePass.php
+++ b/src/DependencyInjection/Compiler/RouteResourcePass.php
@@ -17,8 +17,6 @@ use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * RouteResourcePass registers the route resources on RouteSlotLoader service.
- *
- * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
 final class RouteResourcePass implements CompilerPassInterface
 {

--- a/src/ResourceLoader.php
+++ b/src/ResourceLoader.php
@@ -35,7 +35,7 @@ final class ResourceLoader extends Loader
     /**
      * Noop implementation, always returns false.
      */
-    public function supports($resource, string $type = null)
+    public function supports($resource, string $type = null): bool
     {
         return false;
     }

--- a/src/RouteCollectionBuilder.php
+++ b/src/RouteCollectionBuilder.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * This file is part of the Rollerworks RouteAutowiringBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\RouteAutowiringBundle;
+
+use Symfony\Component\Config\Exception\LoaderLoadException;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Config\Resource\ResourceInterface;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+/** @internal */
+final class RouteCollectionBuilder
+{
+    /** @var LoaderInterface */
+    private $loader;
+
+    /**
+     * @var Route[]|RouteCollectionBuilder[]
+     */
+    private $routes = [];
+
+    /** @var string|null */
+    private $prefix;
+
+    /** @var ResourceInterface[] */
+    private $resources = [];
+
+    public function __construct(LoaderInterface $loader = null)
+    {
+        $this->loader = $loader;
+    }
+
+    public function import($resource, string $prefix = '/', string $type = null)
+    {
+        /** @var RouteCollection[] $collections */
+        $collections = $this->load($resource, $type);
+
+        $builder = new self($this->loader);
+
+        foreach ($collections as $collection) {
+            foreach ($collection->all() as $name => $route) {
+                $builder->routes[$name] = $route;
+            }
+
+            foreach ($collection->getResources() as $resource) {
+                $builder->resources[] = $resource;
+            }
+        }
+
+        // mount into this builder
+        $builder->prefix = trim(trim($prefix), '/');
+        $this->routes[] = $builder;
+
+        return $builder;
+    }
+
+    public function build(): RouteCollection
+    {
+        $routeCollection = new RouteCollection();
+
+        foreach ($this->routes as $name => $route) {
+            if ($route instanceof Route) {
+                if (null !== $this->prefix) {
+                    $route->setPath('/'.$this->prefix.$route->getPath());
+                }
+
+                $routeCollection->add($name, $route);
+            } else {
+                /* @var self $route */
+                $subCollection = $route->build();
+                if (null !== $this->prefix) {
+                    $subCollection->addPrefix($this->prefix);
+                }
+
+                $routeCollection->addCollection($subCollection);
+            }
+        }
+
+        foreach ($this->resources as $resource) {
+            $routeCollection->addResource($resource);
+        }
+
+        return $routeCollection;
+    }
+
+    /**
+     * Finds a loader able to load an imported resource and loads it.
+     *
+     * @param mixed       $resource A resource
+     * @param string|null $type     The resource type or null if unknown
+     *
+     * @return RouteCollection[]
+     *
+     * @throws LoaderLoadException If no loader is found
+     */
+    private function load($resource, string $type = null): array
+    {
+        if (null === $this->loader) {
+            throw new \BadMethodCallException('Cannot import other routing resources: you must pass a LoaderInterface when constructing RouteCollectionBuilder.');
+        }
+
+        if ($this->loader->supports($resource, $type)) {
+            $collections = $this->loader->load($resource, $type);
+
+            return \is_array($collections) ? $collections : [$collections];
+        }
+
+        if (null === $resolver = $this->loader->getResolver()) {
+            throw new LoaderLoadException($resource, null, null, null, $type);
+        }
+
+        if (false === $loader = $resolver->resolve($resource, $type)) {
+            throw new LoaderLoadException($resource, null, null, null, $type);
+        }
+
+        $collections = $loader->load($resource, $type);
+
+        return \is_array($collections) ? $collections : [$collections];
+    }
+}

--- a/src/RouteImporter.php
+++ b/src/RouteImporter.php
@@ -33,8 +33,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  * The `[...]/backend.yml` resource is registered in the backend routing-slot (with the type set explicitly).
  *
  * Then your routing file you load the `frontend` resource with type `rollerworks_autowiring`.
- *
- * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
 final class RouteImporter
 {
@@ -49,14 +47,12 @@ final class RouteImporter
     private $defaultSlot;
 
     /**
-     * Constructor.
-     *
      * @param ContainerBuilder $container   the ContainerBuilder instance
      *                                      for registering the service definitions on
      * @param string|null      $defaultSlot default slot for resources
      *                                      (can be overwritten per resource)
      */
-    public function __construct(ContainerBuilder $container, $defaultSlot = null)
+    public function __construct(ContainerBuilder $container, ?string $defaultSlot = null)
     {
         $this->container = $container;
         $this->defaultSlot = $defaultSlot;
@@ -86,7 +82,7 @@ final class RouteImporter
      *
      * @return $this The current instance
      */
-    public function addObjectResource($object)
+    public function addObjectResource(object $object)
     {
         $this->addClassResource(new \ReflectionClass($object));
 
@@ -122,7 +118,7 @@ final class RouteImporter
      *
      * @return $this The current instance
      */
-    public function import($resource, $slot = null, $type = null)
+    public function import($resource, ?string $slot = null, ?string $type = null)
     {
         if (null === $slot) {
             $slot = $this->defaultSlot;

--- a/src/RouteResource.php
+++ b/src/RouteResource.php
@@ -18,8 +18,6 @@ namespace Rollerworks\Bundle\RouteAutowiringBundle;
  * and should not be used outside this package.
  *
  * @internal
- *
- * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
 final class RouteResource
 {
@@ -33,7 +31,7 @@ final class RouteResource
      */
     private $type;
 
-    public function __construct($resource, $type = null)
+    public function __construct($resource, ?string $type = null)
     {
         $this->resource = $resource;
         $this->type = $type;
@@ -47,10 +45,7 @@ final class RouteResource
         return $this->resource;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getType()
+    public function getType(): ?string
     {
         return $this->type;
     }

--- a/src/RouteSlotLoader.php
+++ b/src/RouteSlotLoader.php
@@ -18,8 +18,6 @@ use Symfony\Component\Routing\RouteCollection;
 
 /**
  * RouteSlotLoader loads from pre-registered routing slots.
- *
- * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  */
 final class RouteSlotLoader extends Loader
 {
@@ -39,15 +37,10 @@ final class RouteSlotLoader extends Loader
     private $resources;
 
     /**
-     * Constructor.
-     *
-     * @param ContainerInterface  $container
-     * @param string[]            $slots
      * @param ResourceInterface[] $resources
      */
-    public function __construct($container, array $slots, array $resources = [])
+    public function __construct(ContainerInterface $container, array $resources = [])
     {
-        $this->slots = $slots;
         $this->container = $container;
         $this->resources = $resources;
     }
@@ -55,18 +48,15 @@ final class RouteSlotLoader extends Loader
     /**
      * Loads a RouteCollection from a routing slot.
      *
-     * @param mixed       $resource Some value that will resolve to a callable
-     * @param string|null $type     The resource type
-     *
      * @return RouteCollection returns an empty RouteCollection object when no routes
      *                         are registered for the slot
      */
     public function load($resource, string $type = null): RouteCollection
     {
-        if (!isset($this->slots[$resource])) {
+        if (!$this->container->has($resource)) {
             $collection = new RouteCollection();
         } else {
-            $collection = $this->container->get($this->slots[$resource])->build();
+            $collection = $this->container->get($resource)->build();
         }
 
         foreach ($this->resources as $trackedResource) {
@@ -76,14 +66,6 @@ final class RouteSlotLoader extends Loader
         return $collection;
     }
 
-    /**
-     * Returns whether this class supports the given resource.
-     *
-     * @param mixed       $resource A resource
-     * @param string|null $type     The resource type or null if unknown
-     *
-     * @return bool True if this class supports the given resource, false otherwise
-     */
     public function supports($resource, string $type = null): bool
     {
         return 'rollerworks_autowiring' === $type;

--- a/tests/DependencyInjection/Compiler/RouteAutowiringPassTest.php
+++ b/tests/DependencyInjection/Compiler/RouteAutowiringPassTest.php
@@ -14,6 +14,7 @@ namespace Rollerworks\Bundle\RouteAutowiringBundle\Tests\DependencyInjection\Com
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use Rollerworks\Bundle\RouteAutowiringBundle\DependencyInjection\Compiler\RouteAutowiringPass;
 use Rollerworks\Bundle\RouteAutowiringBundle\ResourceLoader;
+use Rollerworks\Bundle\RouteAutowiringBundle\RouteCollectionBuilder;
 use Rollerworks\Bundle\RouteAutowiringBundle\RouteImporter;
 use Rollerworks\Bundle\RouteAutowiringBundle\RouteSlotLoader;
 use Symfony\Component\Config\FileLocator;
@@ -21,7 +22,6 @@ use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Routing\Loader\YamlFileLoader;
-use Symfony\Component\Routing\RouteCollectionBuilder;
 
 final class RouteAutowiringPassTest extends AbstractCompilerPassTestCase
 {
@@ -127,6 +127,6 @@ final class RouteAutowiringPassTest extends AbstractCompilerPassTestCase
             $paramValue[$slot] = 'rollerworks_route_autowiring.routing_slot.'.$slot;
         }
 
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument('rollerworks_route_autowiring.route_loader', 1, $paramValue);
+        $this->assertContainerBuilderHasServiceDefinitionWithServiceLocatorArgument('rollerworks_route_autowiring.route_loader', 0, $paramValue);
     }
 }

--- a/tests/RouteCollectionBuilderTest.php
+++ b/tests/RouteCollectionBuilderTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Rollerworks RouteAutowiringBundle package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Bundle\RouteAutowiringBundle\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Rollerworks\Bundle\RouteAutowiringBundle\RouteCollectionBuilder;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Config\Loader\LoaderResolverInterface;
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Routing\Loader\YamlFileLoader;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * @group legacy
+ */
+class RouteCollectionBuilderTest extends TestCase
+{
+    public function testImport()
+    {
+        $resolvedLoader = $this->getMockBuilder(LoaderInterface::class)->getMock();
+        $resolver = $this->getMockBuilder(LoaderResolverInterface::class)->getMock();
+        $resolver->expects($this->once())
+            ->method('resolve')
+            ->with('admin_routing.yml', 'yaml')
+            ->willReturn($resolvedLoader);
+
+        $originalRoute = new Route('/foo/path');
+        $expectedCollection = new RouteCollection();
+        $expectedCollection->add('one_test_route', $originalRoute);
+        $expectedCollection->addResource(new FileResource(__DIR__.'/Fixtures/file_resource.yml'));
+
+        $resolvedLoader
+            ->expects($this->once())
+            ->method('load')
+            ->with('admin_routing.yml', 'yaml')
+            ->willReturn($expectedCollection);
+
+        $loader = $this->getMockBuilder(LoaderInterface::class)->getMock();
+        $loader->expects($this->any())
+            ->method('getResolver')
+            ->willReturn($resolver);
+
+        // import the file!
+        $routes = new RouteCollectionBuilder($loader);
+        $importedRoutes = $routes->import('admin_routing.yml', '/', 'yaml');
+
+        // get the collection back so we can look at it
+        $addedCollection = $importedRoutes->build();
+        $route = $addedCollection->get('one_test_route');
+        $this->assertEquals($originalRoute, $route);
+        // should return file_resource.yml, which is in the original collection
+        $this->assertCount(1, $addedCollection->getResources());
+
+        // make sure the routes were imported into the top-level builder
+        $routeCollection = $routes->build();
+        $this->assertCount(1, $routes->build());
+        $this->assertCount(1, $routeCollection->getResources());
+    }
+
+    public function testImportAddResources()
+    {
+        $routeCollectionBuilder = new RouteCollectionBuilder(new YamlFileLoader(new FileLocator([__DIR__.'/Fixtures/'])));
+        $routeCollectionBuilder->import('file_resource.yml');
+        $routeCollection = $routeCollectionBuilder->build();
+
+        $this->assertCount(1, $routeCollection->getResources());
+    }
+
+    public function testImportWithoutLoaderThrowsException()
+    {
+        $this->expectException('BadMethodCallException');
+        $collectionBuilder = new RouteCollectionBuilder();
+        $collectionBuilder->import('routing.yml');
+    }
+
+    public function testAddsThePrefixOnlyOnceWhenLoadingMultipleCollections()
+    {
+        $firstCollection = new RouteCollection();
+        $firstCollection->add('a', new Route('/a'));
+
+        $secondCollection = new RouteCollection();
+        $secondCollection->add('b', new Route('/b'));
+
+        $loader = $this->getMockBuilder(LoaderInterface::class)->getMock();
+        $loader->expects($this->any())
+            ->method('supports')
+            ->willReturn(true);
+        $loader
+            ->expects($this->any())
+            ->method('load')
+            ->willReturn([$firstCollection, $secondCollection]);
+
+        $routeCollectionBuilder = new RouteCollectionBuilder($loader);
+        $routeCollectionBuilder->import('/directory/recurse/*', '/other/', 'glob');
+        $routes = $routeCollectionBuilder->build()->all();
+
+        $this->assertCount(2, $routes);
+        $this->assertEquals('/other/a', $routes['a']->getPath());
+        $this->assertEquals('/other/b', $routes['b']->getPath());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | Fix #11 
| License       | MIT

This changes internal details to simplify the code, and removes the BC layer of Symfony 2.
Secondly this fixes the deprecation of the `RouteCollectionBuilder` in Symfony.
